### PR TITLE
 Remove `version` element from docker compose yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Set up:
 This assumes you followed the instructions and have a `.env` file in the same repo as a `docker-compose.yml` file with the following:
 
 ```
-version: "3.9"
 services:
   medialytics:
     image: ghcr.io/drewpeifer/medialytics:latest

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   medialytics:
     build: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   medialytics:
     image: ghcr.io/drewpeifer/medialytics:latest


### PR DESCRIPTION
Small change that removes the obsolete `version` element from docker compose yaml.

[See here for reference](https://docs.docker.com/reference/compose-file/version-and-name/).